### PR TITLE
Feat/micropost test

### DIFF
--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,2 +1,4 @@
 class Micropost < ApplicationRecord
+  validates :content, presence: true
+  validates :user_id, presence: true
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,4 +1,4 @@
 class Micropost < ApplicationRecord
-  validates :content, presence: true
+  validates :content, presence: true, length:{ maximum:140 }
   validates :user_id, presence: true
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,4 +1,4 @@
 class Micropost < ApplicationRecord
-  validates :content, presence: true, length:{ maximum:140 }
+  validates :content, presence: true, length: { maximum: 140 }
   validates :user_id, presence: true
 end

--- a/spec/models/micropost_spec.rb
+++ b/spec/models/micropost_spec.rb
@@ -1,5 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe Micropost, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:micropost) { create(:micropost) }
+
+  context 'バリデーション' do
+    it 'マイクロポストが有効である' do
+      expect(micropost).to be_valid
+    end
+
+    it 'コンテントがない場合は無効である' do
+      micropost = build(:micropost, content: '    ')
+      micropost.valid?
+      expect(micropost.errors[:content]).to include("can't be blank")
+    end
+
+    it 'ユーザーがない場合は無効である' do
+      micropost = build(:micropost, user_id: nil)
+      micropost.valid?
+      expect(micropost.errors[:user_id]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/models/micropost_spec.rb
+++ b/spec/models/micropost_spec.rb
@@ -19,5 +19,11 @@ RSpec.describe Micropost, type: :model do
       micropost.valid?
       expect(micropost.errors[:user_id]).to include("can't be blank")
     end
+
+    it 'コンテントが140文字以内であること' do
+      micropost = build(:micropost, content: 'a' * 141)
+      micropost.valid?
+      expect(micropost.errors[:content]).to include('is too long (maximum is 140 characters)')
+    end
   end
 end


### PR DESCRIPTION
close #12 

## 概要

- Micropostの最大文字数を140文字に制限する

## 修正内容の検証方法

- Micropostモデルのvalidatesにlengthを追加
- RSpecにテストを追加

## この修正が正しい理由

- テストコマンドが正常に完了したことを確認
